### PR TITLE
add an initial version of a jetpack client utility

### DIFF
--- a/packages/testpilot-utils/README.md
+++ b/packages/testpilot-utils/README.md
@@ -1,0 +1,3 @@
+This is a Test Pilot client utility library.
+
+The goal here is to make it easy for clients to use Test Pilot in their code.

--- a/packages/testpilot-utils/lib/utils.js
+++ b/packages/testpilot-utils/lib/utils.js
@@ -1,0 +1,62 @@
+// TESTPILOT-UTILS
+"use strict";
+
+const { Cu } = require("chrome"),
+      { AddonManager } = Cu.import("resource://gre/modules/AddonManager.jsm", {}),
+      ObserverService = require("observer-service"),
+      { id } = require("self");
+
+const JETPACK2_ID = "testpilot2@mozilla.org";
+
+// This is kind of lame but I don't want to block the module loading so we'll
+// buffer up the items we get until we can check if the jetpack add-on is installed
+// NOTE that we only do buffering on initial load, if you've been running for a while
+// and install TP later you'll only get events from that point on
+var buffer = true;
+var notifications = [];
+
+var isTestPilotInstalled = false;
+
+function setIsTestPilotInstalled(addon, installed) {
+  if (addon.id == JETPACK2_ID) {
+    isTestPilotInstalled = installed;
+  }
+}
+
+var AddonListener = {
+  onInstalled : function onInstalled(addon) {
+    setIsTestPilotInstalled(addon, true);
+  },
+  onUninstalled : function onUninstalled(addon) {
+    setIsTestPilotInstalled(addon, false);
+  }
+};
+
+AddonManager.addAddonListener(AddonListener);
+
+AddonManager.getAllAddons(function(aAddons) {
+  // look through all the aAddons of {{AMInterface("Addon")}} objects for jetpack
+  aAddons.some(function(addon) {
+    setIsTestPilotInstalled(addon, true);
+    return isTestPilotInstalled;
+  });
+
+  // stop the buffering we may have been doing
+  buffer = false;
+
+  // send out the buffered notifications
+  while(notifications.length) {
+    // take from the top and send out the notifications in the order we got them in
+    exports.notify(notifications.shift());
+  };
+});
+
+exports.notify = function(subject) {
+  //console.log(id, " to notify ", JSON.stringify(subject), isTestPilotInstalled);
+  if (buffer) {
+    notifications.push(subject);
+  }
+  if (isTestPilotInstalled) {
+    ObserverService.notify(id, subject);
+  }
+}

--- a/packages/testpilot-utils/package.json
+++ b/packages/testpilot-utils/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "testpilot-utils",
+  "fullName": "testpilot-utils",
+  "description": "Test Pilot SDK development made easy",
+  "author": "Bryan Clark (http://clarkbw.net/)",
+  "license": "MPL 2.0",
+  "version": "0.1",
+  "dependencies": ["api-utils"]
+}

--- a/packages/testpilot-utils/test/test-utils.js
+++ b/packages/testpilot-utils/test/test-utils.js
@@ -1,0 +1,28 @@
+const { Cu } = require("chrome"),
+      AddonInstaller = require("api-utils/addon/installer"),
+      ObserverService = require("observer-service"),
+      { id, data } = require("self");
+
+const testFolderURL = module.uri.split('test-utils.js')[0];
+const ADDON_URL = testFolderURL + "fixtures/testpilot2-fake.xpi";
+const ADDON_PATH = require("test-harness/tmp-file").createFromURL(ADDON_URL);
+
+exports.test_run = function(test) {
+  test.pass("Unit test running!");
+};
+
+// Installs the Test Pilot Fake add-on
+// Then attempts to use the notify function from the module
+// Waits for the notification to come through the observer service
+exports.test_notify = function(test) {
+  var subject = { "test" : "a test" };
+
+  ObserverService.add(id, function(aSubject, aData) {
+    //console.log("subject", aSubject, "data", aData);
+    test.assertEqual(subject, aSubject, "subjects are not equal");
+    test.done();
+  });
+
+  AddonInstaller.install(ADDON_PATH).then(function success(value) { require("utils").notify(subject); })
+  test.waitUntilDone(10 * 1000);
+};


### PR DESCRIPTION
I wrote this for SDK users who want to push things to Test Pilot without worrying about the details of Test Pilot.  I was also going to do a separate utils for Test Pilot to use the same framework for listening to all add-on id notifications.

You don't have to take things in this direction but it seemed simplest to me.  I wrote up the unit test for the code as well.
